### PR TITLE
Update Heroes.tsx

### DIFF
--- a/src/ui/compositions/Sections/Heroes.tsx
+++ b/src/ui/compositions/Sections/Heroes.tsx
@@ -4,7 +4,7 @@ export type HeroProps = Omit<SectionProps, "padding" | "paddingY" | "paddingX">;
 export function Hero({ children, ...props }: HeroProps) {
   return (
     <Section padding="1600">
-      <Flex container alignPrimary="center" gap="600" {...props}>
+      <Flex container alignPrimary="center" alignSecondary="center" gap="600" direction="column" {...props}>
         {children}
       </Flex>
     </Section>


### PR DESCRIPTION
Hi team,

While preparing a demo, The Hero component is not aligning as the Example/Homepage in Figma SDS file.
<img width="674" alt="image" src="https://github.com/user-attachments/assets/6a7ae33b-80d3-4626-b5d6-91b76e6dba74">

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/1570a2ce-d169-4495-85a2-faa40c8d4832">

Updated Heroes.tsx file **alignSecondary="center", direction="column"** to fix this
