### PR TITLE
Fix children's layer name

### DIFF
--- a/src/figma/compositions/Pages.figma.tsx
+++ b/src/figma/compositions/Pages.figma.tsx
@@ -79,7 +79,7 @@ figma.connect(Section, "<FIGMA_SECTIONS_PAGE_PRODUCT>", {
 
 figma.connect(Section, "<FIGMA_SECTIONS_PAGE_NEWSLETTER>", {
   props: {
-    children: figma.children(["Text Content Heading", "Form Newsletter"]),
+    children: figma.children(["Text Content Heading", "Page Newsletter"]),
     padding: figma.enum("Platform", { Desktop: "1600", Mobile: "600" }),
     gap: figma.enum("Platform", { Desktop: "1200", Mobile: "600" }),
   },


### PR DESCRIPTION
`npx figma connect publish` validation step fails because "Form Newsletter" cannot be found; and it should be "Page Newsletter"

<img width="241" alt="Screenshot 2024-12-02 at 15 32 21" src="https://github.com/user-attachments/assets/9693ceeb-d428-4725-be90-478bc6ee27fd">
