### PR TITLE
update README with latest scope names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,17 @@ Whether you’re looking to use SDS to start a new project, or are looking for e
 
 ### Figma Auth
 
-- [Create a Figma API token](https://www.figma.com/developers/api#authentication)
-  - Add Code Connect scope
-  - Add File Read, Dev Resources Write, and Variables scopes if you want to use the integrations in [scripts](./scripts/)
+- [Create a Figma API token](https://www.figma.com/developers/api#authentication) and request the following scopes if you want to use the integrations in [scripts](./scripts/)
+  - ```file_code_connect_scope:write``` - to work with Code Connect
+  - ```file_dev_resources:read```- Read dev resources in files.
+  - ```file_dev_resources:write``` - Write dev resources to files
+  - ```file_variables:read``` - Read variables in files. Note: Enterprise plan only.
+  - ```file_variables:write``` - Write variables and collections in files. Note: Enterprise plan only.
+  - ```file_metadata:read``` - Read metadata of files.
+  - ```file_versions:read``` - Read the version history for files you can access.
   - [More on scopes](https://www.figma.com/developers/api#authentication-scopes)
 - Duplicate [.env-rename](./.env-rename)
-- Rename it to `.env`, it will be ignored from git.
+- Rename it to `.env`, it will be ignored by git.
   - Set `FIGMA_ACCESS_TOKEN=` as your token in `.env`
   - Set `FIGMA_FILE_KEY=` as your file's key (grab it from the file URL) in `.env`
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Whether you’re looking to use SDS to start a new project, or are looking for e
 
 - [Create a Figma API token](https://www.figma.com/developers/api#authentication) and request the following scopes to work with Code Connect
   - ```file_code_connect_scope:write``` - to work with Code Connect
+  - [More on Code Connect scopes](https://developers.figma.com/docs/code-connect/quickstart-guide/#before-you-begin)
 
 and these scopes, if you want to use the integrations in [scripts](./scripts/)
   - ```file_dev_resources:read```- Read dev resources in files.
@@ -31,7 +32,7 @@ and these scopes, if you want to use the integrations in [scripts](./scripts/)
   - ```file_variables:write``` - Write variables and collections in files. Note: Enterprise plan only.
   - ```file_metadata:read``` - Read metadata of files.
   - ```file_versions:read``` - Read the version history for files you can access.
-  - [More on scopes](https://www.figma.com/developers/api#authentication-scopes)
+  - [More on REST API scopes](https://www.figma.com/developers/api#authentication-scopes)
 - Duplicate [.env-rename](./.env-rename)
 - Rename it to `.env`, it will be ignored by git.
   - Set `FIGMA_ACCESS_TOKEN=` as your token in `.env`

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Whether you’re looking to use SDS to start a new project, or are looking for e
 
 ### Figma Auth
 
-- [Create a Figma API token](https://www.figma.com/developers/api#authentication) and request the following scopes if you want to use the integrations in [scripts](./scripts/)
+- [Create a Figma API token](https://www.figma.com/developers/api#authentication) and request the following scopes to work with Code Connect
   - ```file_code_connect_scope:write``` - to work with Code Connect
+
+and these scopes, if you want to use the integrations in [scripts](./scripts/)
   - ```file_dev_resources:read```- Read dev resources in files.
   - ```file_dev_resources:write``` - Write dev resources to files
   - ```file_variables:read``` - Read variables in files. Note: Enterprise plan only.


### PR DESCRIPTION
Updated README to reference the latest draft of scope requirements, based on [updated Figma developer docs](https://developers.figma.com/docs/rest-api/scopes/)