### PR TITLE
Add .figma/make/ config for Figma Make integration

### DIFF
--- a/.figma/make/dev
+++ b/.figma/make/dev
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the Vite dev server with HMR.
+
+cd "$(dirname "$0")/../.."
+
+# Load environment variables
+source .figma/make/env
+
+exec npm run app:dev

--- a/.figma/make/env
+++ b/.figma/make/env
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Environment variables for the project.
+# SDS reads FIGMA_ACCESS_TOKEN and FIGMA_FILE_KEY from a local .env file
+# (see .env-rename). Vite's dev server runs on port 8000 by default
+# (configured in vite.config.ts).
+
+# Dev server
+export VITE_PORT="${VITE_PORT:-8000}"
+export VITE_HOST="${VITE_HOST:-localhost}"
+
+# Figma Make integration
+PORT=8000
+FIGMA_MAKE_URL=http://localhost:8000

--- a/.figma/make/install
+++ b/.figma/make/install
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install project dependencies.
+
+cd "$(dirname "$0")/../.."
+
+npm install
+
+echo "Project dependencies installed."

--- a/.figma/make/setup
+++ b/.figma/make/setup
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initial setup: install system-level dependencies needed to build/run the project.
+
+# Require Node.js >= 18
+if ! command -v node &>/dev/null; then
+  echo "Error: Node.js is not installed. Install Node.js 18+ and re-run." >&2
+  exit 1
+fi
+
+NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "Error: Node.js 18+ is required (found v$(node -v))." >&2
+  exit 1
+fi
+
+# Require npm
+if ! command -v npm &>/dev/null; then
+  echo "Error: npm is not installed." >&2
+  exit 1
+fi
+
+echo "System dependencies OK (Node $(node -v), npm $(npm -v))."

--- a/.figma/make/verify
+++ b/.figma/make/verify
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Verify the project is correctly configured and can build.
+
+cd "$(dirname "$0")/../.."
+
+# Load environment variables
+source .figma/make/env
+
+ERRORS=0
+
+# Check node_modules exist
+if [ ! -d "node_modules" ]; then
+  echo "FAIL: node_modules missing. Run .figma/make/install first." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# TypeScript compilation check
+echo "Checking TypeScript..."
+if npx tsc --noEmit 2>/dev/null; then
+  echo "  OK: TypeScript compiles cleanly."
+else
+  echo "  FAIL: TypeScript errors detected." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Lint check
+echo "Checking ESLint..."
+if npm run app:lint --silent 2>/dev/null; then
+  echo "  OK: No lint errors."
+else
+  echo "  FAIL: Lint errors detected." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Production build check
+echo "Checking production build..."
+if npm run app:build --silent 2>/dev/null; then
+  echo "  OK: Production build succeeded."
+else
+  echo "  FAIL: Production build failed." >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "$ERRORS verification(s) failed."
+  exit 1
+fi
+
+echo ""
+echo "All verifications passed."


### PR DESCRIPTION
Adds the standard Figma Make config scripts (dev, env, install, setup, verify) so the repo can be opened and run by Figma Make, mirroring the convention used in figma/test-figma-make-config.

Scripts are adapted for SDS: dev runs `npm run app:dev` on port 8000 (matching vite.config.ts), and verify uses `npm run app:lint` / `npm run app:build`.