### PR TITLE
Add Settings screen composition from Figma design

### DIFF
--- a/src/ui/compositions/Settings/Settings.tsx
+++ b/src/ui/compositions/Settings/Settings.tsx
@@ -1,0 +1,175 @@
+import { clsx } from "clsx";
+import { Flex } from "layout";
+import { ButtonDanger, SwitchField, Text, TextSmall } from "primitives";
+import { ComponentPropsWithoutRef, ReactNode, useState } from "react";
+import "./settings.css";
+
+// ─── Section label ────────────────────────────────────────────────────────────
+
+type SettingsSectionProps = {
+  label: string;
+  children: ReactNode;
+};
+function SettingsSection({ label, children }: SettingsSectionProps) {
+  return (
+    <div className="settings-section">
+      <TextSmall elementType="p" className="settings-section-label">
+        {label}
+      </TextSmall>
+      <div className="settings-card">{children}</div>
+    </div>
+  );
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+type SettingsRowProps = ComponentPropsWithoutRef<"button"> & {
+  label: string;
+  value?: string;
+  /** When true the row renders a disclosure chevron instead of a value */
+  chevron?: boolean;
+};
+function SettingsRow({
+  label,
+  value,
+  chevron = true,
+  className,
+  ...props
+}: SettingsRowProps) {
+  return (
+    <button className={clsx("settings-row", className)} {...props}>
+      <Text elementType="span" className="settings-row-label">
+        {label}
+      </Text>
+      <Flex
+        direction="row"
+        gap="200"
+        alignSecondary="center"
+        className="settings-row-trailing"
+      >
+        {value && (
+          <TextSmall elementType="span" className="settings-row-value">
+            {value}
+          </TextSmall>
+        )}
+        {chevron && (
+          <span aria-hidden="true" className="settings-row-chevron">
+            ›
+          </span>
+        )}
+      </Flex>
+    </button>
+  );
+}
+
+// ─── Switch row ───────────────────────────────────────────────────────────────
+
+type SettingsSwitchRowProps = {
+  label: string;
+  defaultSelected?: boolean;
+  onChange?: (isSelected: boolean) => void;
+};
+function SettingsSwitchRow({
+  label,
+  defaultSelected = false,
+  onChange,
+}: SettingsSwitchRowProps) {
+  return (
+    <SwitchField
+      label={label}
+      defaultSelected={defaultSelected}
+      onChange={onChange}
+      className="settings-switch-row"
+    />
+  );
+}
+
+// ─── Settings screen ─────────────────────────────────────────────────────────
+
+export type SettingsProps = {
+  /** User display name shown in the Profile row */
+  userName?: string;
+  /** User email shown in the Email row */
+  userEmail?: string;
+  /** Called when the user presses Sign Out */
+  onSignOut?: () => void;
+};
+
+export function Settings({
+  userName = "Brett",
+  userEmail = "brett@example.com",
+  onSignOut,
+}: SettingsProps) {
+  const [theme, setTheme] = useState<"Light" | "Dark">("Light");
+  const [textSize, setTextSize] = useState<"Medium" | "Large">("Medium");
+
+  return (
+    <div className="settings-screen">
+      {/* Nav */}
+      <header className="settings-nav">
+        <button className="settings-back-btn" aria-label="Go back">
+          {"< Back"}
+        </button>
+        <Text elementType="h1" className="settings-nav-title">
+          Settings
+        </Text>
+      </header>
+
+      {/* Scrollable content */}
+      <div className="settings-content">
+        {/* ACCOUNT */}
+        <SettingsSection label="ACCOUNT">
+          <SettingsRow label="Profile" value={userName} />
+          <SettingsRow label="Email" value={userEmail} />
+          <SettingsRow label="Password" value="••••••••" />
+        </SettingsSection>
+
+        {/* NOTIFICATIONS */}
+        <SettingsSection label="NOTIFICATIONS">
+          <SettingsSwitchRow label="Push Notifications" defaultSelected />
+          <SettingsSwitchRow label="Email Notifications" />
+        </SettingsSection>
+
+        {/* APPEARANCE */}
+        <SettingsSection label="APPEARANCE">
+          <SettingsRow
+            label="Theme"
+            value={theme}
+            onClick={() => setTheme(t => (t === "Light" ? "Dark" : "Light"))}
+          />
+          <SettingsRow
+            label="Text Size"
+            value={textSize}
+            onClick={() =>
+              setTextSize(s => (s === "Medium" ? "Large" : "Medium"))
+            }
+          />
+        </SettingsSection>
+
+        {/* PRIVACY */}
+        <SettingsSection label="PRIVACY">
+          <SettingsSwitchRow label="Data Sharing" />
+          <SettingsSwitchRow label="Analytics" defaultSelected />
+        </SettingsSection>
+
+        {/* ABOUT */}
+        <SettingsSection label="ABOUT">
+          <SettingsRow label="Version" value="2.4.1" chevron={false} />
+          <SettingsRow label="Terms of Service" />
+          <SettingsRow label="Privacy Policy" />
+        </SettingsSection>
+
+        {/* SIGN OUT */}
+        <div className="settings-section">
+          <ButtonDanger
+            variant="danger-subtle"
+            className="settings-signout-btn"
+            onPress={onSignOut}
+          >
+            Sign Out
+          </ButtonDanger>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/compositions/Settings/settings.css
+++ b/src/ui/compositions/Settings/settings.css
@@ -1,0 +1,138 @@
+/* ── Screen ──────────────────────────────────────────────────────────────── */
+.settings-screen {
+  display: flex;
+  flex-direction: column;
+  width: 393px;
+  height: 852px;
+  background-color: var(--color-background-subtle, #f2f2f7);
+  font-family: var(--font-family-base, -apple-system, BlinkMacSystemFont, "Inter", sans-serif);
+  overflow: hidden;
+}
+
+/* ── Nav bar ─────────────────────────────────────────────────────────────── */
+.settings-nav {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 56px;
+  flex-shrink: 0;
+  padding: 0 16px;
+  background-color: var(--color-background-subtle, #f2f2f7);
+}
+
+.settings-nav-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--color-text-primary, #000);
+  margin: 0;
+}
+
+.settings-back-btn {
+  position: absolute;
+  left: 16px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: 17px;
+  color: var(--color-action-primary, #007aff);
+}
+
+/* ── Content ─────────────────────────────────────────────────────────────── */
+.settings-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 0 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ── Section ─────────────────────────────────────────────────────────────── */
+.settings-section {
+  margin-bottom: 24px;
+  padding: 0 16px;
+}
+
+.settings-section-label {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--color-text-subtle, #6d6d72);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  margin: 0 0 6px 16px;
+}
+
+/* ── Card ────────────────────────────────────────────────────────────────── */
+.settings-card {
+  background-color: var(--color-background-primary, #fff);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.settings-card > * + * {
+  border-top: 0.5px solid var(--color-border-subtle, #e0e0e0);
+}
+
+/* ── Row ─────────────────────────────────────────────────────────────────── */
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 50px;
+  padding: 0 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.settings-row-label {
+  font-size: 17px;
+  color: var(--color-text-primary, #000);
+  flex: 1;
+}
+
+.settings-row-trailing {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.settings-row-value {
+  font-size: 17px;
+  color: var(--color-text-subtle, #8e8e93);
+}
+
+.settings-row-chevron {
+  font-size: 22px;
+  color: var(--color-text-subtle, #8e8e93);
+  line-height: 1;
+  margin-top: -2px;
+}
+
+/* ── Switch row ──────────────────────────────────────────────────────────── */
+.settings-switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 50px;
+  padding: 0 16px;
+}
+
+.settings-switch-row .switch-field {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+/* ── Sign Out ────────────────────────────────────────────────────────────── */
+.settings-signout-btn {
+  width: 100%;
+  border-radius: 12px;
+}

--- a/src/ui/compositions/index.ts
+++ b/src/ui/compositions/index.ts
@@ -4,3 +4,4 @@ export * from "./Forms/Forms";
 export * from "./Headers/Headers";
 export * from "./Sections/Heroes";
 export * from "./Sections/Panels";
+export * from "./Settings/Settings";


### PR DESCRIPTION
Adds a new Settings page (created in Figma) as a React component using the project's design system primitives — Button, SwitchField, Text — and matching the iOS-style grouped list layout from the Figma design file.