### PR TITLE
String interpolation fixes + formatting pass

### DIFF
--- a/src/figma/compositions/card-grid/CardGridPricing.figma.ts
+++ b/src/figma/compositions/card-grid/CardGridPricing.figma.ts
@@ -19,14 +19,23 @@ export default {
     const gap = isMobile ? "600" : "1200";
     const gapCards = isMobile ? "600" : "1200";
     const size = isMobile ? "small" : "large";
-    return (<Section padding={padding}>
+
+    return (
+      <Section padding={padding}>
         <Flex container direction="column" gap={gap}>
           ${schedule}
           <Flex container direction="row" gap={gapCards}>
-            {monthlyPlans.map((option, i) => (<PricingCard key={option.sku} size={size} {...pricingPlanToPricingCardProps(option, i)}/>))}
+            {monthlyPlans.map((option, i) => (
+              <PricingCard
+                key={option.sku}
+                size={size}
+                {...pricingPlanToPricingCardProps(option, i)}
+              />
+            ))}
           </Flex>
         </Flex>
-      </Section>);
+      </Section>
+    );
 }`,
   metadata: { nestable: false },
 }

--- a/src/figma/compositions/card/PricingCard.figma.ts
+++ b/src/figma/compositions/card/PricingCard.figma.ts
@@ -40,6 +40,20 @@ const variant = instance.getEnum("Variant", {
 export default {
   id: "PricingCard",
   imports: ['import { PricingCard } from "compositions";'],
-  example: figma.code`<PricingCard heading="${heading}" action="${action?.label}"${action?.icon ? ` actionIcon={${action.icon}}` : ""} actionVariant="${action?.variant}" onAction={() => { }} listSlot={${list}} interval="month" sku="example_sku" price="${textPrice?.price}" priceCurrency="${textPrice?.currency}" priceLabel="${textPrice?.label}" size="${textPrice?.size}" variant="${variant}"/>`,
+  example: figma.code`<PricingCard
+      heading="${heading}"
+      action="${action?.label}"
+      ${action?.icon ? figma.code`actionIcon={${action.icon}}` : ""}
+      actionVariant="${action?.variant}"
+      onAction={() => {}}
+      listSlot={${list}}
+      interval="month"
+      sku="example_sku"
+      price="${textPrice?.price}"
+      priceCurrency="${textPrice?.currency}"
+      priceLabel="${textPrice?.label}"
+      size="${textPrice?.size}"
+      variant="${variant}"
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/compositions/card/ProductInfoCard.figma.ts
+++ b/src/figma/compositions/card/ProductInfoCard.figma.ts
@@ -27,6 +27,19 @@ export default {
     'import { Image } from "primitives";',
     'import { placeholder } from "images";',
   ],
-  example: figma.code`<ProductInfoCard asset={<Image src={placeholder} size="medium" aspectRatio="natural" alt="Always describe images"/>} rating={4.5} heading="${heading}" price="${price}" description="${description}"/>`,
+  example: figma.code`<ProductInfoCard
+      asset={
+        <Image
+          src={placeholder}
+          size="medium"
+          aspectRatio="natural"
+          alt="Always describe images"
+        />
+      }
+      rating={4.5}
+      heading="${heading}"
+      price="${price}"
+      description="${description}"
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/compositions/card/ReviewCard.figma.ts
+++ b/src/figma/compositions/card/ReviewCard.figma.ts
@@ -28,6 +28,13 @@ export default {
     'import { ReviewCard } from "compositions";',
     'import { placeholder } from "images";',
   ],
-  example: figma.code`<ReviewCard stars={5} src={placeholder} title="${title}" body="${body}" date="${date}" name="${name}"/>`,
+  example: figma.code`<ReviewCard
+      stars={5}
+      src={placeholder}
+      title="${title}"
+      body="${body}"
+      date="${date}"
+      name="${name}"
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/compositions/card/StatsCard.figma.ts
+++ b/src/figma/compositions/card/StatsCard.figma.ts
@@ -21,6 +21,6 @@ const icon = instance.getInstanceSwap("Icon")?.executeTemplate().example;
 export default {
   id: "StatsCard",
   imports: ['import { StatsCard } from "compositions";'],
-  example: figma.code`<StatsCard description="${description}" stat="${stat}" icon={${icon}}/>`,
+  example: figma.code`<StatsCard description="${description}" stat="${stat}" icon={${icon}} />`,
   metadata: { nestable: true },
 };

--- a/src/figma/compositions/card/TestimonialCard.figma.ts
+++ b/src/figma/compositions/card/TestimonialCard.figma.ts
@@ -24,6 +24,11 @@ export default {
     'import { TestimonialCard } from "compositions";',
     'import { placeholder } from "images";',
   ],
-  example: figma.code`<TestimonialCard heading="${heading}" src={placeholder} name="${name}" username="${username}"/>`,
+  example: figma.code`<TestimonialCard
+      heading="${heading}"
+      src={placeholder}
+      name="${name}"
+      username="${username}"
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/compositions/form/FormContact.figma.ts
+++ b/src/figma/compositions/form/FormContact.figma.ts
@@ -13,6 +13,6 @@ const children = figma.properties.children([
 export default {
   id: "FormBox",
   imports: ['import { FormBox } from "compositions";'],
-  example: figma.code`<FormBox onSubmit={() => { }}>${children}</FormBox>`,
+  example: figma.code`<FormBox onSubmit={() => {}}>${children}</FormBox>`,
   metadata: { nestable: true },
 }

--- a/src/figma/compositions/form/FormForgotPassword.figma.ts
+++ b/src/figma/compositions/form/FormForgotPassword.figma.ts
@@ -9,6 +9,6 @@ const children = figma.properties.children(["Input Field", "Button Group"])
 export default {
   id: "FormBox",
   imports: ['import { FormBox } from "compositions";'],
-  example: figma.code`<FormBox onSubmit={() => { }}>${children}</FormBox>`,
+  example: figma.code`<FormBox onSubmit={() => {}}>${children}</FormBox>`,
   metadata: { nestable: true },
 }

--- a/src/figma/compositions/form/FormLogIn.figma.ts
+++ b/src/figma/compositions/form/FormLogIn.figma.ts
@@ -13,6 +13,6 @@ const children = figma.properties.children([
 export default {
   id: "FormBox",
   imports: ['import { FormBox } from "compositions";'],
-  example: figma.code`<FormBox onSubmit={() => { }}>${children}</FormBox>`,
+  example: figma.code`<FormBox onSubmit={() => {}}>${children}</FormBox>`,
   metadata: { nestable: true },
 }

--- a/src/figma/compositions/form/FormNewsletter.figma.ts
+++ b/src/figma/compositions/form/FormNewsletter.figma.ts
@@ -9,7 +9,7 @@ const children = figma.properties.children(["Input Field", "Button"])
 export default {
   id: "FormBox",
   imports: ['import { Form } from "primitives";'],
-  example: figma.code`<Form singleLine onSubmit={() => { }}>
+  example: figma.code`<Form singleLine onSubmit={() => {}}>
       ${children}
     </Form>`,
   metadata: { nestable: true },

--- a/src/figma/compositions/form/FormRegister.figma.ts
+++ b/src/figma/compositions/form/FormRegister.figma.ts
@@ -13,6 +13,6 @@ const children = figma.properties.children([
 export default {
   id: "FormBox",
   imports: ['import { FormBox } from "compositions";'],
-  example: figma.code`<FormBox onSubmit={() => { }}>${children}</FormBox>`,
+  example: figma.code`<FormBox onSubmit={() => {}}>${children}</FormBox>`,
   metadata: { nestable: true },
 }

--- a/src/figma/compositions/form/FormShipping.figma.ts
+++ b/src/figma/compositions/form/FormShipping.figma.ts
@@ -19,7 +19,7 @@ export default {
     'import { FormBox } from "compositions";',
     'import { Flex } from "layout";',
   ],
-  example: figma.code`<FormBox onSubmit={() => { }}>
+  example: figma.code`<FormBox onSubmit={() => {}}>
       <Flex direction="column" gap="100">
         ${legend}
       </Flex>

--- a/src/figma/compositions/page/PageNewsletter.figma.ts
+++ b/src/figma/compositions/page/PageNewsletter.figma.ts
@@ -21,7 +21,15 @@ export default {
   id: "Section",
   imports: ['import { Flex, Section } from "layout";'],
   example: figma.code`<Section padding="${padding}">
-      <Flex container wrap gap="${gap}" direction="column" alignPrimary="center" alignSecondary="center" type="third">
+      <Flex
+        container
+        wrap
+        gap="${gap}"
+        direction="column"
+        alignPrimary="center"
+        alignSecondary="center"
+        type="third"
+      >
         ${children}
       </Flex>
     </Section>`,

--- a/src/figma/compositions/page/PageProduct.figma.ts
+++ b/src/figma/compositions/page/PageProduct.figma.ts
@@ -28,7 +28,12 @@ export default {
   ],
   example: figma.code`<Section padding="${padding}">
       <Flex container type="half" wrap gap="${gap}">
-        <Image src={placeholder} alt="Always use image alt" size="large" aspectRatio="4-3"/>
+        <Image
+          src={placeholder}
+          alt="Always use image alt"
+          size="large"
+          aspectRatio="4-3"
+        />
         <FlexItem size="half">
           <Flex direction="column" gap="600" alignSecondary="stretch">
             ${textHeading}

--- a/src/figma/compositions/panel/PanelImage.figma.ts
+++ b/src/figma/compositions/panel/PanelImage.figma.ts
@@ -20,7 +20,12 @@ export default {
   example: figma.code`<Section padding="${padding}">
       <Panel type="auto">
         <FlexItem size="full">
-          <Image src={placeholder} alt="Always use image alt" aspectRatio="fill" size="medium"/>
+          <Image
+            src={placeholder}
+            alt="Always use image alt"
+            aspectRatio="fill"
+            size="medium"
+          />
         </FlexItem>
       </Panel>
     </Section>`,

--- a/src/figma/compositions/panel/PanelImageContent.figma.ts
+++ b/src/figma/compositions/panel/PanelImageContent.figma.ts
@@ -24,7 +24,12 @@ export default {
   ],
   example: figma.code`<Section padding="${padding}">
       <Panel gap="${gap}" type="half">
-        <Image src={placeholder} alt="Always use image alt" aspectRatio="4-3" size="medium"/>
+        <Image
+          src={placeholder}
+          alt="Always use image alt"
+          aspectRatio="4-3"
+          size="medium"
+        />
         <FlexItem size="half">
           <Flex direction="column" gap="600">
             ${children}

--- a/src/figma/compositions/panel/PanelImageContentReverse.figma.ts
+++ b/src/figma/compositions/panel/PanelImageContentReverse.figma.ts
@@ -29,7 +29,12 @@ export default {
             ${children}
           </Flex>
         </FlexItem>
-        <Image src={placeholder} alt="Always use image alt" aspectRatio="4-3" size="medium"/>
+        <Image
+          src={placeholder}
+          alt="Always use image alt"
+          aspectRatio="4-3"
+          size="medium"
+        />
       </Panel>
     </Section>`,
   metadata: { nestable: true },

--- a/src/figma/compositions/panel/PanelImageDouble.figma.ts
+++ b/src/figma/compositions/panel/PanelImageDouble.figma.ts
@@ -23,8 +23,18 @@ export default {
   ],
   example: figma.code`<Section padding="${padding}">
       <Panel gap="${gap}" type="half">
-        <Image src={placeholder} alt="Always use image alt" aspectRatio="4-3" size="medium"/>
-        <Image src={placeholder} alt="Always use image alt" aspectRatio="4-3" size="medium"/>
+        <Image
+          src={placeholder}
+          alt="Always use image alt"
+          aspectRatio="4-3"
+          size="medium"
+        />
+        <Image
+          src={placeholder}
+          alt="Always use image alt"
+          aspectRatio="4-3"
+          size="medium"
+        />
       </Panel>
     </Section>`,
   metadata: { nestable: true },

--- a/src/figma/icons/Icons.figma.batch.ts
+++ b/src/figma/icons/Icons.figma.batch.ts
@@ -14,6 +14,8 @@ const size = figma.batch.hasSizeVariants
 export default {
   id: component,
   imports: [`import { ${component} } from "icons";`],
-  example: figma.code`<${component}${size ? ` size="${size}"` : ""} />`,
+  example: figma.code`<${component}
+      ${size ? figma.code`size="${size}"` : ""}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/IconButton.figma.ts
+++ b/src/figma/primitives/IconButton.figma.ts
@@ -21,7 +21,13 @@ const size = instance.getEnum("Size", {
 export default {
   id: "IconButton",
   imports: ['import { IconButton } from "primitives";'],
-  example: figma.code`<IconButton aria-label="Write a nice description of the action." onPress={() => { }}${variant ? ` variant="${variant}"` : ""}${size ? ` size="${size}"` : ""}${isDisabled ? " isDisabled" : ""}>
+  example: figma.code`<IconButton
+      aria-label="Write a nice description of the action."
+      onPress={() => {}}
+      ${variant ? figma.code`variant="${variant}"` : ""}
+      ${size ? figma.code`size="${size}"` : ""}
+      ${isDisabled ? "isDisabled" : ""}
+    >
       ${icon}
     </IconButton>`,
   metadata: { nestable: true },

--- a/src/figma/primitives/IconButton.figma.ts
+++ b/src/figma/primitives/IconButton.figma.ts
@@ -5,6 +5,7 @@
 import figma from "figma";
 
 const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
 const variant = instance.getEnum("Variant", {
   Primary: "primary",
   Neutral: "neutral",
@@ -24,9 +25,9 @@ export default {
   example: figma.code`<IconButton
       aria-label="Write a nice description of the action."
       onPress={() => {}}
-      ${variant ? figma.code`variant="${variant}"` : ""}
-      ${size ? figma.code`size="${size}"` : ""}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("variant", variant)}
+      ${rp("size", size)}
+      ${rp("isDisabled", isDisabled)}
     >
       ${icon}
     </IconButton>`,

--- a/src/figma/primitives/InputField.figma.ts
+++ b/src/figma/primitives/InputField.figma.ts
@@ -35,7 +35,7 @@ export default {
   id: "InputField",
   imports,
   example: figma.code`<${hasLabel ? "InputField" : "Input"}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("isDisabled", isDisabled)}
       ${rp("errorMessage", errorMessage)}
       ${rp("label", label)}
       ${rp("description", description)}

--- a/src/figma/primitives/InputField.figma.ts
+++ b/src/figma/primitives/InputField.figma.ts
@@ -34,6 +34,13 @@ const imports = hasLabel
 export default {
   id: "InputField",
   imports,
-  example: figma.code`<${hasLabel ? "InputField" : "Input"}${isDisabled ? " isDisabled" : ""}${rp("errorMessage", errorMessage)}${rp("label", label)}${rp("description", description)}${rp("value", value)}${rp("placeholder", placeholder)}/>`,
+  example: figma.code`<${hasLabel ? "InputField" : "Input"}
+      ${isDisabled ? "isDisabled" : ""}
+      ${rp("errorMessage", errorMessage)}
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${rp("value", value)}
+      ${rp("placeholder", placeholder)}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/Notification.figma.ts
+++ b/src/figma/primitives/Notification.figma.ts
@@ -2,32 +2,35 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Notification/Notification.tsx
 // component=Notification
 
-import figma from "figma"
+import figma from "figma";
 
-const title = figma.selectedInstance.getString("Title")
-const icon = figma.selectedInstance.getBoolean("Has Icon", {
-  true: figma.selectedInstance.getInstanceSwap("Icon")?.executeTemplate()
-    .example,
+const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
+
+const title = instance.getString("Title");
+const icon = instance.getBoolean("Has Icon", {
+  true: instance.getInstanceSwap("Icon")?.executeTemplate().example,
   false: undefined,
-})
-const isDismissible = figma.selectedInstance.getBoolean("Dismissible")
-const button = figma.properties.children(["Button"])
-const body = figma.selectedInstance.getString("Body")
-const variant = figma.selectedInstance.getEnum("Variant", {
+});
+const isDismissible = instance.getBoolean("Dismissible");
+const button = figma.properties.children(["Button"]);
+const body = instance.getString("Body");
+const variant = instance.getEnum("Variant", {
   Message: "message",
   Alert: "alert",
-})
+});
 
 export default {
   id: "Notification",
   imports: ['import { Notification, Text, TextStrong } from "primitives";'],
-  example: figma.code`<Notification${figma.helpers.react.renderProp(
-    "icon",
-    icon,
-  )}${isDismissible ? " isDismissible" : ""} variant="${variant}">
+  example: figma.code`<Notification
+    ${rp("icon", icon)}
+    ${rp("isDismissible", isDismissible)}
+    ${rp("variant", variant)}
+    >
       <TextStrong>${title}</TextStrong>
       <Text>${body}</Text>
       ${button}
     </Notification>`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/Search.figma.ts
+++ b/src/figma/primitives/Search.figma.ts
@@ -22,7 +22,7 @@ export default {
   example: figma.code`<Search
       ${rp("value", value)}
       ${rp("placeholder", placeholder)}
-      ${disabled ? "disabled" : ""}
+      ${rp("disabled", disabled)}
     />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/Search.figma.ts
+++ b/src/figma/primitives/Search.figma.ts
@@ -19,6 +19,10 @@ const disabled = instance.getEnum("State", { Disabled: true });
 export default {
   id: "Search",
   imports: ['import { Search } from "primitives";'],
-  example: figma.code`<Search${rp("value", value)}${rp("placeholder", placeholder)}${disabled ? " disabled" : ""}/>`,
+  example: figma.code`<Search
+      ${rp("value", value)}
+      ${rp("placeholder", placeholder)}
+      ${disabled ? "disabled" : ""}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/SelectField.figma.ts
+++ b/src/figma/primitives/SelectField.figma.ts
@@ -46,7 +46,7 @@ export default {
   imports,
   example: figma.code`<${hasLabel ? "SelectField" : "Select"}
       ${rp("defaultSelectedKey", defaultSelectedKey)}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("isDisabled", isDisabled)}
       ${rp("errorMessage", errorMessage)}
       ${rp("label", label)}
       ${rp("description", description)}

--- a/src/figma/primitives/SelectField.figma.ts
+++ b/src/figma/primitives/SelectField.figma.ts
@@ -44,7 +44,15 @@ const imports = hasLabel
 export default {
   id: "SelectField",
   imports,
-  example: figma.code`<${hasLabel ? "SelectField" : "Select"}${rp("defaultSelectedKey", defaultSelectedKey)}${isDisabled ? " isDisabled" : ""}${rp("errorMessage", errorMessage)}${rp("label", label)}${rp("description", description)}${rp("value", value)}${rp("placeholder", placeholder)}>
+  example: figma.code`<${hasLabel ? "SelectField" : "Select"}
+      ${rp("defaultSelectedKey", defaultSelectedKey)}
+      ${isDisabled ? "isDisabled" : ""}
+      ${rp("errorMessage", errorMessage)}
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${rp("value", value)}
+      ${rp("placeholder", placeholder)}
+    >
       <SelectItem>${defaultSelectedKey}</SelectItem>
       <SelectItem>Option 2</SelectItem>
       <SelectItem>Option 3</SelectItem>

--- a/src/figma/primitives/SliderField.figma.ts
+++ b/src/figma/primitives/SliderField.figma.ts
@@ -17,6 +17,11 @@ const description = instance.getBoolean("Has Description", {
 export default {
   id: "SliderField",
   imports: ['import { SliderField } from "primitives";'],
-  example: figma.code`<SliderField${isDisabled ? " isDisabled" : ""}${rp("label", label)}${rp("description", description)} showOutput/>`,
+  example: figma.code`<SliderField
+      ${isDisabled ? "isDisabled" : ""}
+      ${rp("label", label)}
+      ${rp("description", description)}
+      showOutput
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/SliderField.figma.ts
+++ b/src/figma/primitives/SliderField.figma.ts
@@ -18,7 +18,7 @@ export default {
   id: "SliderField",
   imports: ['import { SliderField } from "primitives";'],
   example: figma.code`<SliderField
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("isDisabled", isDisabled)}
       ${rp("label", label)}
       ${rp("description", description)}
       showOutput

--- a/src/figma/primitives/SwitchField.figma.ts
+++ b/src/figma/primitives/SwitchField.figma.ts
@@ -21,8 +21,8 @@ export default {
   example: figma.code`<SwitchField
       ${rp("label", label)}
       ${rp("description", description)}
-      ${defaultSelected ? "defaultSelected" : ""}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("defaultSelected", defaultSelected)}
+      ${rp("isDisabled", isDisabled)}
     />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/SwitchField.figma.ts
+++ b/src/figma/primitives/SwitchField.figma.ts
@@ -18,6 +18,11 @@ const isDisabled = instance.getEnum("State", { Disabled: true });
 export default {
   id: "SwitchField",
   imports: ['import { SwitchField } from "primitives";'],
-  example: figma.code`<SwitchField${rp("label", label)}${rp("description", description)}${defaultSelected ? " defaultSelected" : ""}${isDisabled ? " isDisabled" : ""}/>`,
+  example: figma.code`<SwitchField
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${defaultSelected ? "defaultSelected" : ""}
+      ${isDisabled ? "isDisabled" : ""}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/TextareaField.figma.ts
+++ b/src/figma/primitives/TextareaField.figma.ts
@@ -35,6 +35,13 @@ const imports = hasLabel
 export default {
   id: "TextareaField",
   imports,
-  example: figma.code`<${hasLabel ? "TextareaField" : "Textarea"}${isDisabled ? " isDisabled" : ""}${rp("errorMessage", errorMessage)}${rp("label", label)}${rp("description", description)}${rp("value", value)}${rp("placeholder", placeholder)}/>`,
+  example: figma.code`<${hasLabel ? "TextareaField" : "Textarea"}
+      ${isDisabled ? "isDisabled" : ""}
+      ${rp("errorMessage", errorMessage)}
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${rp("value", value)}
+      ${rp("placeholder", placeholder)}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/TextareaField.figma.ts
+++ b/src/figma/primitives/TextareaField.figma.ts
@@ -36,7 +36,7 @@ export default {
   id: "TextareaField",
   imports,
   example: figma.code`<${hasLabel ? "TextareaField" : "Textarea"}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("isDisabled", isDisabled)}
       ${rp("errorMessage", errorMessage)}
       ${rp("label", label)}
       ${rp("description", description)}

--- a/src/figma/primitives/accordion/AccordionItem.figma.ts
+++ b/src/figma/primitives/accordion/AccordionItem.figma.ts
@@ -9,6 +9,6 @@ const children = figma.selectedInstance.getString("Content");
 export default {
   id: "AccordionItem",
   imports: ['import { AccordionItem } from "primitives";'],
-  example: figma.code`<AccordionItem title="${title}" children="${children}"/>`,
+  example: figma.code`<AccordionItem title="${title}" children="${children}" />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/avatar/Avatar.figma.ts
+++ b/src/figma/primitives/avatar/Avatar.figma.ts
@@ -2,13 +2,16 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Avatar/Avatar.tsx
 // component=Avatar
 
-import figma from "figma"
+import figma from "figma";
 
-const instance = figma.selectedInstance
-const square = instance.getEnum("Shape", { Square: true })
-const size = instance.getEnum("Size", { Large: "large", Small: "small" })
-const initials = instance.getEnum("Type", { Initial: instance.getString("Initials") })
-const src = instance.getEnum("Type", { Image: true })
+const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
+const square = instance.getEnum("Shape", { Square: true });
+const size = instance.getEnum("Size", { Large: "large", Small: "small" });
+const initials = instance.getEnum("Type", {
+  Initial: instance.getString("Initials"),
+});
+const src = instance.getEnum("Type", { Image: true });
 
 export default {
   id: "Avatar",
@@ -17,10 +20,10 @@ export default {
     'import { placeholder } from "images";',
   ],
   example: figma.code`<Avatar
-      ${square ? "square" : ""}
-      ${initials ? figma.code`initials="${initials}"` : ""}
-      ${size ? figma.code`size="${size}"` : ""}
-      ${src ? "src={placeholder}" : ""}
+      ${rp("square", square)}
+      ${rp("initials", initials)}
+      ${rp("size", size)}
+      ${rp("src", src ? "placeholder" : undefined)}
     />`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/avatar/Avatar.figma.ts
+++ b/src/figma/primitives/avatar/Avatar.figma.ts
@@ -16,6 +16,11 @@ export default {
     'import { Avatar } from "primitives";',
     'import { placeholder } from "images";',
   ],
-  example: figma.code`<Avatar${square ? " square" : ""}${initials ? ` initials="${initials}"` : ""}${size ? ` size="${size}"` : ""}${src ? " src={placeholder}" : ""}/>`,
+  example: figma.code`<Avatar
+      ${square ? "square" : ""}
+      ${initials ? figma.code`initials="${initials}"` : ""}
+      ${size ? figma.code`size="${size}"` : ""}
+      ${src ? "src={placeholder}" : ""}
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/avatar/AvatarBlock.figma.ts
+++ b/src/figma/primitives/avatar/AvatarBlock.figma.ts
@@ -12,6 +12,11 @@ const children = figma.properties.children(["Avatar"])
 export default {
   id: "AvatarBlock",
   imports: ['import { AvatarBlock } from "primitives";'],
-  example: figma.code`<AvatarBlock title="${title}" description="${description}">${children}</AvatarBlock>`,
+  example: figma.code`<AvatarBlock
+      title="${title}"
+      description="${description}"
+    >
+      ${children}
+    </AvatarBlock>`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/avatar/AvatarGroup.figma.ts
+++ b/src/figma/primitives/avatar/AvatarGroup.figma.ts
@@ -14,7 +14,10 @@ const children = figma.properties.children(["Avatar"])
 export default {
   id: "AvatarGroup",
   imports: ['import { AvatarGroup } from "primitives";'],
-  example: figma.code`<AvatarGroup${spacing ? ` spacing="${spacing}"` : ""} max={3}>
+  example: figma.code`<AvatarGroup
+      ${spacing ? figma.code`spacing="${spacing}"` : ""}
+      max={3}
+    >
       ${children}
     </AvatarGroup>`,
   metadata: { nestable: true },

--- a/src/figma/primitives/button/Button.figma.ts
+++ b/src/figma/primitives/button/Button.figma.ts
@@ -5,6 +5,7 @@
 import figma from "figma";
 
 const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
 const variant = instance.getEnum("Variant", {
   Primary: "primary",
   Neutral: "neutral",
@@ -31,9 +32,9 @@ export default {
   imports: ['import { Button } from "primitives";'],
   example: figma.code`<Button
       onPress={() => {}}
-      ${variant ? figma.code`variant="${variant}"` : ""}
-      ${size ? figma.code`size="${size}"` : ""}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("variant", variant)}
+      ${rp("size", size)}
+      ${rp("isDisabled", isDisabled)}
     >
       ${iconStart}
       ${label}

--- a/src/figma/primitives/button/Button.figma.ts
+++ b/src/figma/primitives/button/Button.figma.ts
@@ -29,7 +29,12 @@ const isDisabled = instance.getEnum("State", {
 export default {
   id: "Button",
   imports: ['import { Button } from "primitives";'],
-  example: figma.code`<Button onPress={() => { }}${variant ? ` variant="${variant}"` : ""}${size ? ` size="${size}"` : ""}${isDisabled ? " isDisabled" : ""}>
+  example: figma.code`<Button
+      onPress={() => {}}
+      ${variant ? figma.code`variant="${variant}"` : ""}
+      ${size ? figma.code`size="${size}"` : ""}
+      ${isDisabled ? "isDisabled" : ""}
+    >
       ${iconStart}
       ${label}
       ${iconEnd}

--- a/src/figma/primitives/button/ButtonDanger.figma.ts
+++ b/src/figma/primitives/button/ButtonDanger.figma.ts
@@ -5,6 +5,7 @@
 import figma from "figma";
 
 const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
 
 const variant = instance.getEnum("Variant", {
   Subtle: "danger-subtle",
@@ -30,9 +31,9 @@ export default {
   imports: ['import { ButtonDanger } from "primitives";'],
   example: figma.code`<ButtonDanger
       onPress={() => {}}
-      ${variant ? figma.code`variant="${variant}"` : ""}
-      ${size ? figma.code`size="${size}"` : ""}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("variant", variant)}
+      ${rp("size", size)}
+      ${rp("isDisabled", isDisabled)}
     >
       ${iconStart}
       ${label}

--- a/src/figma/primitives/button/ButtonDanger.figma.ts
+++ b/src/figma/primitives/button/ButtonDanger.figma.ts
@@ -28,7 +28,12 @@ const isDisabled = instance.getEnum("State", {
 export default {
   id: "Button",
   imports: ['import { ButtonDanger } from "primitives";'],
-  example: figma.code`<ButtonDanger onPress={() => { }}${variant ? ` variant="${variant}"` : ""}${size ? ` size="${size}"` : ""}${isDisabled ? " isDisabled" : ""}>
+  example: figma.code`<ButtonDanger
+      onPress={() => {}}
+      ${variant ? figma.code`variant="${variant}"` : ""}
+      ${size ? figma.code`size="${size}"` : ""}
+      ${isDisabled ? "isDisabled" : ""}
+    >
       ${iconStart}
       ${label}
       ${iconEnd}

--- a/src/figma/primitives/button/ButtonGroup.figma.ts
+++ b/src/figma/primitives/button/ButtonGroup.figma.ts
@@ -16,6 +16,10 @@ const children = figma.properties.children(["Button"]);
 export default {
   id: "ButtonGroup",
   imports: ['import { ButtonGroup } from "primitives";'],
-  example: figma.code`<ButtonGroup${align ? ` align="${align}"` : ""}>${children}</ButtonGroup>`,
+  example: figma.code`<ButtonGroup
+      ${align ? figma.code`align="${align}"` : ""}
+    >
+      ${children}
+    </ButtonGroup>`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/button/ButtonGroup.figma.ts
+++ b/src/figma/primitives/button/ButtonGroup.figma.ts
@@ -4,6 +4,7 @@
 
 import figma from "figma";
 const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
 
 const align = instance.getEnum("Align", {
   Center: "center",
@@ -17,7 +18,7 @@ export default {
   id: "ButtonGroup",
   imports: ['import { ButtonGroup } from "primitives";'],
   example: figma.code`<ButtonGroup
-      ${align ? figma.code`align="${align}"` : ""}
+      ${rp("align", align)}
     >
       ${children}
     </ButtonGroup>`,

--- a/src/figma/primitives/checkbox/CheckboxField.figma.ts
+++ b/src/figma/primitives/checkbox/CheckboxField.figma.ts
@@ -24,6 +24,12 @@ const isDisabled = instance.getEnum("State", { Disabled: true });
 export default {
   id: "CheckboxField",
   imports: ['import { CheckboxField } from "primitives";'],
-  example: figma.code`<CheckboxField${rp("label", label)}${rp("description", description)}${defaultSelected ? " defaultSelected" : ""}${isIndeterminate ? " isIndeterminate" : ""}${isDisabled ? " isDisabled" : ""}/>`,
+  example: figma.code`<CheckboxField
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${defaultSelected ? "defaultSelected" : ""}
+      ${isIndeterminate ? "isIndeterminate" : ""}
+      ${isDisabled ? "isDisabled" : ""}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/checkbox/CheckboxField.figma.ts
+++ b/src/figma/primitives/checkbox/CheckboxField.figma.ts
@@ -27,9 +27,9 @@ export default {
   example: figma.code`<CheckboxField
       ${rp("label", label)}
       ${rp("description", description)}
-      ${defaultSelected ? "defaultSelected" : ""}
-      ${isIndeterminate ? "isIndeterminate" : ""}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("defaultSelected", defaultSelected)}
+      ${rp("isIndeterminate", isIndeterminate)}
+      ${rp("isDisabled", isDisabled)}
     />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/dialog/Dialog.figma.ts
+++ b/src/figma/primitives/dialog/Dialog.figma.ts
@@ -12,7 +12,7 @@ export default {
       'import { Button } from "primitives";',
       'import { ButtonGroup } from "primitives";',
   ],
-  example: figma.code`<DialogModal isDismissable isOpen={true} onOpenChange={() => { }}>
+  example: figma.code`<DialogModal isDismissable isOpen={true} onOpenChange={() => {}}>
       ${children}
     </DialogModal>`,
   metadata: { nestable: true },

--- a/src/figma/primitives/dialog/DialogBody.figma.ts
+++ b/src/figma/primitives/dialog/DialogBody.figma.ts
@@ -20,7 +20,7 @@ export default {
     'import { Button } from "primitives";',
   ],
   example: figma.code`<Dialog type="${type}">
-      <DialogClose onPress={() => { }}/>
+      <DialogClose onPress={() => {}} />
       <DialogTitle>${heading}</DialogTitle>
       <DialogBody>${body}</DialogBody>
       ${buttons}

--- a/src/figma/primitives/navigation/NavigationButton.figma.ts
+++ b/src/figma/primitives/navigation/NavigationButton.figma.ts
@@ -2,26 +2,29 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Navigation/Navigation.tsx
 // component=NavigationButton
 
-import figma from "figma"
+import figma from "figma";
 
-const label = figma.selectedInstance.getString("Label")
-const icon = figma.selectedInstance.getBoolean("Has Icon", {
-  true: figma.selectedInstance.getInstanceSwap("Icon")?.executeTemplate()
-    .example,
+const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
+const label = instance.getString("Label");
+const icon = instance.getBoolean("Has Icon", {
+  true: instance.getInstanceSwap("Icon")?.executeTemplate().example,
   false: undefined,
-})
-const isSelected = figma.selectedInstance.getEnum("State", {
+});
+const isSelected = instance.getEnum("State", {
   Active: true,
   Default: undefined,
   Hover: undefined,
-})
+});
 
 export default {
   id: "NavigationButton",
   imports: ['import { NavigationButton } from "primitives";'],
-  example: figma.code`<NavigationButton${figma.helpers.react.renderProp(
-    "icon",
-    icon,
-  )}${isSelected ? " isSelected" : ""}>${label}</NavigationButton>`,
+  example: figma.code`<NavigationButton
+      ${rp("icon", icon)}
+      ${rp("isSelected", isSelected)}
+    >
+      ${label}
+    </NavigationButton>`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/navigation/NavigationPill.figma.ts
+++ b/src/figma/primitives/navigation/NavigationPill.figma.ts
@@ -2,18 +2,23 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Navigation/Navigation.tsx
 // component=NavigationPill
 
-import figma from "figma"
+import figma from "figma";
 
-const label = figma.selectedInstance.getString("Label")
+const label = figma.selectedInstance.getString("Label");
+const rp = figma.helpers.react.renderProp;
 const isSelected = figma.selectedInstance.getEnum("State", {
   Active: true,
   Default: undefined,
   Hover: undefined,
-})
+});
 
 export default {
   id: "NavigationPill",
   imports: ['import { NavigationPill } from "primitives";'],
-  example: figma.code`<NavigationPill${isSelected ? " isSelected" : ""}>${label}</NavigationPill>`,
+  example: figma.code`<NavigationPill
+    ${rp("isSelected", isSelected)}
+  >
+    ${label}
+  </NavigationPill>`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/pagination/PaginationNext.figma.ts
+++ b/src/figma/primitives/pagination/PaginationNext.figma.ts
@@ -12,6 +12,8 @@ const href = figma.selectedInstance.getEnum("State", {
 export default {
   id: "PaginationNext",
   imports: ['import { PaginationNext } from "primitives";'],
-  example: figma.code`<PaginationNext${href ? ` href="${href}"` : ""}/>`,
+  example: figma.code`<PaginationNext
+      ${href ? figma.code`href="${href}"` : ""}
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/pagination/PaginationPage.figma.ts
+++ b/src/figma/primitives/pagination/PaginationPage.figma.ts
@@ -14,6 +14,11 @@ const href = figma.selectedInstance.getString("Number")
 export default {
   id: "PaginationPage",
   imports: ['import { PaginationPage } from "primitives";'],
-  example: figma.code`<PaginationPage${current ? " current" : ""}${figma.helpers.react.renderProp("href", href)}>${number}</PaginationPage>`,
+  example: figma.code`<PaginationPage
+      ${current ? "current" : ""}
+      ${figma.helpers.react.renderProp("href", href)}
+    >
+      ${number}
+    </PaginationPage>`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/pagination/PaginationPage.figma.ts
+++ b/src/figma/primitives/pagination/PaginationPage.figma.ts
@@ -2,23 +2,26 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Pagination/Pagination.tsx
 // component=PaginationPage
 
-import figma from "figma"
+import figma from "figma";
 
-const number = figma.selectedInstance.getString("Number")
-const current = figma.selectedInstance.getEnum("State", {
+const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
+
+const number = instance.getString("Number");
+const current = instance.getEnum("State", {
   Current: true,
   "Current Hover": true,
-})
-const href = figma.selectedInstance.getString("Number")
+});
+const href = instance.getString("Href");
 
 export default {
   id: "PaginationPage",
   imports: ['import { PaginationPage } from "primitives";'],
   example: figma.code`<PaginationPage
-      ${current ? "current" : ""}
-      ${figma.helpers.react.renderProp("href", href)}
+      ${rp("current", current)}
+      ${rp("href", href)}
     >
       ${number}
     </PaginationPage>`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/pagination/PaginationPrevious.figma.ts
+++ b/src/figma/primitives/pagination/PaginationPrevious.figma.ts
@@ -12,6 +12,8 @@ const href = figma.selectedInstance.getEnum("State", {
 export default {
   id: "PaginationPrevious",
   imports: ['import { PaginationPrevious } from "primitives";'],
-  example: figma.code`<PaginationPrevious${href ? ` href="${href}"` : ""}/>`,
+  example: figma.code`<PaginationPrevious
+      ${href ? figma.code`href="${href}"` : ""}
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/radio/RadioField.figma.ts
+++ b/src/figma/primitives/radio/RadioField.figma.ts
@@ -17,6 +17,11 @@ const isDisabled = instance.getEnum("State", { Disabled: true });
 export default {
   id: "RadioField",
   imports: ['import { RadioField } from "primitives";'],
-  example: figma.code`<RadioField value="Initial value"${rp("label", label)}${rp("description", description)}${isDisabled ? " isDisabled" : ""}/>`,
+  example: figma.code`<RadioField
+      value="Initial value"
+      ${rp("label", label)}
+      ${rp("description", description)}
+      ${isDisabled ? "isDisabled" : ""}
+    />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/radio/RadioField.figma.ts
+++ b/src/figma/primitives/radio/RadioField.figma.ts
@@ -21,7 +21,7 @@ export default {
       value="Initial value"
       ${rp("label", label)}
       ${rp("description", description)}
-      ${isDisabled ? "isDisabled" : ""}
+      ${rp("isDisabled", isDisabled)}
     />`,
   metadata: { nestable: true },
 };

--- a/src/figma/primitives/tag/Tag.figma.ts
+++ b/src/figma/primitives/tag/Tag.figma.ts
@@ -22,6 +22,12 @@ const scheme = figma.selectedInstance.getEnum("Scheme", {
 export default {
   id: "Tag",
   imports: ['import { Tag } from "primitives";'],
-  example: figma.code`<Tag${onRemove ? " onRemove={() => {}}" : ""}${variant ? ` variant="${variant}"` : ""}${scheme ? ` scheme="${scheme}"` : ""}>${label}</Tag>`,
+  example: figma.code`<Tag
+      ${onRemove ? "onRemove={() => {}}" : ""}
+      ${variant ? figma.code`variant="${variant}"` : ""}
+      ${scheme ? figma.code`scheme="${scheme}"` : ""}
+    >
+      ${label}
+    </Tag>`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/tag/Tag.figma.ts
+++ b/src/figma/primitives/tag/Tag.figma.ts
@@ -2,32 +2,35 @@
 // source=https://github.com/figma/sds/blob/main/src/ui/primitives/Tag/Tag.tsx
 // component=Tag
 
-import figma from "figma"
+import figma from "figma";
 
-const onRemove = figma.selectedInstance.getBoolean("Removable", {
+const instance = figma.selectedInstance;
+const rp = figma.helpers.react.renderProp;
+
+const onRemove = instance.getBoolean("Removable", {
   true: figma.helpers.react.function("() => {}"),
   false: undefined,
-})
-const label = figma.selectedInstance.getString("Label")
-const variant = figma.selectedInstance.getEnum("Variant", {
+});
+const label = instance.getString("Label");
+const variant = instance.getEnum("Variant", {
   Secondary: "secondary",
-})
+});
 const scheme = figma.selectedInstance.getEnum("Scheme", {
   Danger: "danger",
   Positive: "positive",
   Warning: "warning",
   Neutral: "neutral",
-})
+});
 
 export default {
   id: "Tag",
   imports: ['import { Tag } from "primitives";'],
   example: figma.code`<Tag
-      ${onRemove ? "onRemove={() => {}}" : ""}
-      ${variant ? figma.code`variant="${variant}"` : ""}
-      ${scheme ? figma.code`scheme="${scheme}"` : ""}
+      ${rp("onRemove", "onRemove={() => {}}")}
+      ${rp("variant", variant)}
+      ${rp("scheme", scheme)}
     >
       ${label}
     </Tag>`,
   metadata: { nestable: true },
-}
+};

--- a/src/figma/primitives/tag/TagToggle.figma.ts
+++ b/src/figma/primitives/tag/TagToggle.figma.ts
@@ -12,7 +12,10 @@ const iconStart = figma.selectedInstance
 export default {
   id: "TagToggle",
   imports: ['import { TagToggle } from "primitives";'],
-  example: figma.code`<TagToggle${figma.helpers.react.renderProp("id", label)}${figma.helpers.react.renderProp("iconStart", iconStart)}>
+  example: figma.code`<TagToggle
+      ${figma.helpers.react.renderProp("id", label)}
+      ${figma.helpers.react.renderProp("iconStart", iconStart)}
+    >
       ${label}
     </TagToggle>`,
   metadata: { nestable: true },

--- a/src/figma/primitives/text/TextContentHeading.figma.ts
+++ b/src/figma/primitives/text/TextContentHeading.figma.ts
@@ -13,9 +13,10 @@ const subheading = figma.selectedInstance.getString("Subheading")
 export default {
   id: "TextContentHeading",
   imports: ['import { TextContentHeading } from "primitives";'],
-  example: figma.code`<TextContentHeading${align ? ` align="${align}"` : ""}${figma.helpers.react.renderProp(
-    "heading",
-    heading,
-  )}${figma.helpers.react.renderProp("subheading", subheading)}/>`,
+  example: figma.code`<TextContentHeading
+      ${align ? figma.code`align="${align}"` : ""}
+      ${figma.helpers.react.renderProp("heading", heading)}
+      ${figma.helpers.react.renderProp("subheading", subheading)}
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/text/TextContentTitle.figma.ts
+++ b/src/figma/primitives/text/TextContentTitle.figma.ts
@@ -13,9 +13,10 @@ const subtitle = figma.selectedInstance.getString("Subtitle")
 export default {
   id: "TextContentTitle",
   imports: ['import { TextContentTitle } from "primitives";'],
-  example: figma.code`<TextContentTitle${align ? ` align="${align}"` : ""}${figma.helpers.react.renderProp(
-    "title",
-    title,
-  )}${figma.helpers.react.renderProp("subtitle", subtitle)}/>`,
+  example: figma.code`<TextContentTitle
+      ${align ? figma.code`align="${align}"` : ""}
+      ${figma.helpers.react.renderProp("title", title)}
+      ${figma.helpers.react.renderProp("subtitle", subtitle)}
+    />`,
   metadata: { nestable: true },
 }

--- a/src/figma/primitives/text/TextPrice.figma.ts
+++ b/src/figma/primitives/text/TextPrice.figma.ts
@@ -14,12 +14,11 @@ const price = figma.selectedInstance.getString("Price")
 export default {
   id: "TextPrice",
   imports: ['import { TextPrice } from "primitives";'],
-  example: figma.code`<TextPrice${figma.helpers.react.renderProp(
-    "label",
-    label,
-  )}${size ? ` size="${size}"` : ""}${figma.helpers.react.renderProp(
-    "currency",
-    currency,
-  )}${figma.helpers.react.renderProp("price", price)}/>`,
+  example: figma.code`<TextPrice
+      ${figma.helpers.react.renderProp("label", label)}
+      ${size ? figma.code`size="${size}"` : ""}
+      ${figma.helpers.react.renderProp("currency", currency)}
+      ${figma.helpers.react.renderProp("price", price)}
+    />`,
   metadata: { nestable: true },
 }


### PR DESCRIPTION
When interpolating a Figma value into a string, this should be wrapped in `figma.code` to ensure nested instances or errors can render correctly. Fixed some that I missed in my last PR.

Also done a pass of formatting the examples for readability.